### PR TITLE
make libcec + libp8 platform compile under openwrt 22.03

### DIFF
--- a/libcec/Makefile
+++ b/libcec/Makefile
@@ -7,7 +7,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=libcec
 PKG_VERSION:=4.0.2
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE_URL:=https://github.com/Pulse-Eight/libcec/archive/
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
@@ -44,4 +44,18 @@ define Package/libcec/install
 	$(CP) $(PKG_INSTALL_DIR)/usr/lib/*.so* $(1)/usr/lib/
 endef
 
+
+define Package/cec-client
+  SECTION:=utils
+  CATEGORY:=Utilities
+  TITLE:=cec-client
+  DEPENDS:=+libcec
+endef
+
+define Package/cec-client/install
+	$(INSTALL_DIR) $(1)/usr/bin
+	$(CP) -L $(PKG_BUILD_DIR)/src/cec-client/cec-client $(1)/usr/bin/
+endef
+
 $(eval $(call BuildPackage,libcec))
+$(eval $(call BuildPackage,cec-client))

--- a/libcec/Makefile
+++ b/libcec/Makefile
@@ -26,8 +26,9 @@ define Package/libcec
   CATEGORY:=Libraries
   TITLE:=libcec
   DEPENDS:= \
-	+TARGET_brcm2708:raspberrypi-userland \
-	+libstdcpp
+	+TARGET_bcm27xx:bcm27xx-userland \
+	+libstdcpp \
+	+libudev
   URL:=http://libcec.pulse-eight.com/
   MAINTAINER:=Stijn Tintel <stijn@linux-ipv6.be>
 endef

--- a/libcec/patches/999-compile-with-fpermissive.patch
+++ b/libcec/patches/999-compile-with-fpermissive.patch
@@ -1,0 +1,23 @@
+
+--- a/src/libcec/CMakeLists.txt
++++ b/src/libcec/CMakeLists.txt
+@@ -18,6 +18,8 @@ if (SUPPORTS_CXX11)
+   set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++11")
+ endif()
+ 
++set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fpermissive")
++
+ find_package(p8-platform REQUIRED)
+ if (p8-platform_VERSION VERSION_LESS 2.0)
+   message(FATAL_ERROR "p8-platform 2.0+ is required")
+--- a/src/cec-client/CMakeLists.txt
++++ b/src/cec-client/CMakeLists.txt
+@@ -18,6 +18,8 @@ if (SUPPORTS_CXX11)
+   set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++11")
+ endif()
+ 
++set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fpermissive")
++
+ find_package(p8-platform REQUIRED)
+ find_package(Threads REQUIRED)
+ 

--- a/libp8-platform/Makefile
+++ b/libp8-platform/Makefile
@@ -16,6 +16,8 @@ PKG_HASH:=064f8d2c358895c7e0bea9ae956f8d46f3f057772cb97f2743a11d478a0f68a0
 PKG_BUILD_DIR:=$(BUILD_DIR)/platform-p8-platform-$(PKG_VERSION)
 PKG_INSTALL:=1
 
+PKG_USE_NINJA:=0
+
 include $(INCLUDE_DIR)/package.mk
 include $(INCLUDE_DIR)/cmake.mk
 


### PR DESCRIPTION
- libcec needs to be built with -fpermissive as default compiler settings got more strict
- libcec depended on raspberrypi-userland which was renamed to bcm27xx-userland
- libcec has a dependency on libudev which was not listed in the makefile
- libp8-platform needs PKG_USE_NINJA:=0 because apparently the p8 cmake setup does not produce ninja files