### PR TITLE
libcec + libp8-platform: fix build of libcec under modern openwrt

### DIFF
--- a/libcec/Makefile
+++ b/libcec/Makefile
@@ -26,8 +26,9 @@ define Package/libcec
   CATEGORY:=Libraries
   TITLE:=libcec
   DEPENDS:= \
-	+TARGET_brcm2708:raspberrypi-userland \
-	+libstdcpp
+	+TARGET_bcm27xx:bcm27xx-userland \
+	+libstdcpp \
+	+libudev
   URL:=http://libcec.pulse-eight.com/
   MAINTAINER:=Stijn Tintel <stijn@linux-ipv6.be>
 endef

--- a/libcec/patches/999-compile-with-fpermissive.patch
+++ b/libcec/patches/999-compile-with-fpermissive.patch
@@ -1,0 +1,23 @@
+
+--- a/src/libcec/CMakeLists.txt
++++ b/src/libcec/CMakeLists.txt
+@@ -18,6 +18,8 @@ if (SUPPORTS_CXX11)
+   set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++11")
+ endif()
+ 
++set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fpermissive")
++
+ find_package(p8-platform REQUIRED)
+ if (p8-platform_VERSION VERSION_LESS 2.0)
+   message(FATAL_ERROR "p8-platform 2.0+ is required")
+--- a/src/cec-client/CMakeLists.txt
++++ b/src/cec-client/CMakeLists.txt
+@@ -18,6 +18,8 @@ if (SUPPORTS_CXX11)
+   set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++11")
+ endif()
+ 
++set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fpermissive")
++
+ find_package(p8-platform REQUIRED)
+ find_package(Threads REQUIRED)
+ 

--- a/libp8-platform/Makefile
+++ b/libp8-platform/Makefile
@@ -16,6 +16,8 @@ PKG_HASH:=064f8d2c358895c7e0bea9ae956f8d46f3f057772cb97f2743a11d478a0f68a0
 PKG_BUILD_DIR:=$(BUILD_DIR)/platform-p8-platform-$(PKG_VERSION)
 PKG_INSTALL:=1
 
+PKG_USE_NINJA:=0
+
 include $(INCLUDE_DIR)/package.mk
 include $(INCLUDE_DIR)/cmake.mk
 


### PR DESCRIPTION
This is a properly reformatted and signed off PR for now closed [#1](https://github.com/stintel/lede-wip/pull/1)